### PR TITLE
Use custom Limine fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "limine"]
 	path = src/limine
-	url = https://github.com/limine-bootloader/limine.git
-	branch = v4.x-branch-binary
+	url = http://github.com/jlam55555/limine.git
+	branch = trunk
         shallow = true

--- a/README.md
+++ b/README.md
@@ -7,16 +7,27 @@ A personal study on operating systems, with help from the OSDev Wiki. A long-ter
 Make sure to have [QEMU][qemu] and [GNU `make`][make] installed.
 
 ```bash
-# Fetch Limine dependency
-git submodule init
-git submodule update
+# Fetch Limine (bootloader) dependency.
+git submodule update --init
 
-# Build and run either iso or hdd
-make run_iso
-make run_hdd
+# Build Limine (this build is separate from the kernel build)
+make limine
+
+# Build and run in QEMU (run_iso target also available)
+sudo make run_hdd
+
+# Cleanup
+sudo make limine-clean clean
 ```
 
-See the [Makefile](./Makefile) for more possible build targets.
+### Features
+- [X] Limine bootloader (forked to jlam55555/limine to enable VGA text mode 3 by default)
+- [X] PS/2 Keyboard driver: read scancodes, translate to keycodes/ASCII and pass to input subsystem
+- [X] TTY layer: master side reads from input subsystem, writes to console; slave side can be used by processes; no ldisc/cooked mode
+- [X] Console driver: write text to screen, with scrollback; interpret special characters like `^H`, `^M`, `^J`
+- [ ] Shell
+- [ ] Processes
+- [ ] Memory management
 
 ### Learning goals
 


### PR DESCRIPTION
https://github.com/limine-bootloader/limine does not provide a textmode option for the Limine boot protocol (it does, however, seem to provide one for the multiboot2 and Linux protocols). I hack one into the Limine protocol in my custom fork https://github.com/jlam55555/limine.

Previously, I was modifying this Limine source code and pointing the src/limine submodule at my modified version -- which was a mess, and would not build outside of my machine. Creating my own fork of Limine and the changes in this PR should fix this, so that running the instructions in the README should build the OS.

For now, this is the easiest way to get modifications to the bootloader, and doesn't require too much effort on my part. This does complicate the build rules though, and there are a few design decisions to make here:
- Should the jlam55555/limine repo also use a release branch, and the submodule will point to that? This is what the Limine main repo does. However, I haven't used branch build rules yet, and for now it's simpler to pull in the Limine source code and build it as manually. This makes it easier to fiddle around with Limine, but makes the kernel build steps longer/more complicated.
- Should I write my own bootloader? Yes, eventually, but making a few small modifications to the Limine bootloader is enough for now. To make the modification to enable VGA text mode, I need a way to jump back into real mode from protected mode in 64-bit assembly, which is not something I'm comfortable doing at the moment. But the time will come when I do set up a bootloader for myself.