### PR TITLE
Limine v5.x update

### DIFF
--- a/src/kernel/arch/x86_64/pt.h
+++ b/src/kernel/arch/x86_64/pt.h
@@ -55,6 +55,10 @@ _Static_assert(VM_CANON_BITS == VM_HM_START,
 // Similar to the PG_ALIGNED macro.
 #define VM_HGPG_ALIGNED(sz) (!((size_t)(sz) & (VM_HGPG_SZ - 1)))
 
+// Convert addr to/from HHDM version.
+#define VM_TO_DIRECT(addr) (void *)((uint64_t)(addr) & ~VM_HM_START)
+#define VM_TO_HHDM(addr) (void *)((uint64_t)(addr) | VM_HM_START)
+
 /**
  * Page-map level X table (levels 2-4).
  *

--- a/src/kernel/diag/mm.c
+++ b/src/kernel/diag/mm.c
@@ -50,7 +50,7 @@ _check_stk_size(void) {
 }
 
 void _print_pt(struct pmlx_entry *pmlx, int level, void *prev_va) {
-  pmlx = (void *)((size_t)pmlx | VM_HM_START);
+  pmlx = VM_TO_HHDM(pmlx);
   for (uint64_t i = 0; i < (VM_PG_SZ / sizeof *pmlx); ++i) {
     if (!pmlx[i].p) {
       continue;

--- a/src/kernel/drivers/console.h
+++ b/src/kernel/drivers/console.h
@@ -9,6 +9,7 @@
 #ifndef DRIVERS_CONSOLE_H
 #define DRIVERS_CONSOLE_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 /**
@@ -58,6 +59,9 @@ struct console {
   struct console_cursor cursor;
   char *buf;
   struct console_driver *driver;
+
+  // Disabled until memory mappings are set up.
+  bool enabled;
 };
 
 /**
@@ -68,6 +72,9 @@ struct console_driver {
   void (*init_driver)(struct console_driver *);
   void (*scroll)(struct console *, int);
   void (*write)(struct console *, const char *, size_t);
+
+  // Only can be enabled after the memory region is properly mapped.
+  void (*enable)(struct console *);
 };
 
 struct console_driver *get_default_console_driver(void);

--- a/src/kernel/mem/phys.c
+++ b/src/kernel/mem/phys.c
@@ -156,7 +156,7 @@ static void _phys_rr_allocator_init(void *addr, size_t mem_limit,
   _phys_allocator.needle = 0;
 
   // Use HM version of address.
-  _phys_allocator.mem_bitmap = (struct page *)(VM_HM_START | (size_t)addr);
+  _phys_allocator.mem_bitmap = VM_TO_HHDM(addr);
 
   // Initialize bitmap. bm_sz = "bitmap size"
   size_t bm_sz = _phys_allocator.total_pg * sizeof(struct page);

--- a/src/kernel/mem/phys.c
+++ b/src/kernel/mem/phys.c
@@ -52,6 +52,7 @@ static struct _phys_rr_allocator {
  * Returns true iff the physical page is free.
  */
 static bool _phys_page_alloc(void *addr) {
+  addr = VM_TO_DIRECT(addr);
   assert(PG_ALIGNED(addr));
   size_t pg = (size_t)addr >> PG_SZ_BITS;
   assert(pg < _phys_allocator.total_pg);
@@ -159,11 +160,11 @@ static void _phys_rr_allocator_init(void *addr, size_t mem_limit,
 
   // Initialize bitmap. bm_sz = "bitmap size"
   size_t bm_sz = _phys_allocator.total_pg * sizeof(struct page);
-  memset(addr, 0, bm_sz);
+  memset(_phys_allocator.mem_bitmap, 0, bm_sz);
 
   // Mark bitmap pages as allocated. We use the physical address here rather
   // than the HHDM address.
-  _phys_region_alloc(addr, PG_COUNT(bm_sz), false);
+  _phys_region_alloc(_phys_allocator.mem_bitmap, PG_COUNT(bm_sz), false);
 
   // Mark unusable regions in the bitmap.
   void *prev_end = NULL;
@@ -290,7 +291,9 @@ void *phys_page_alloc(void) {
   // pages are used in a LIFO manner.
   void *phys_addr = (void *)((size_t)_phys_allocator.needle << PG_SZ_BITS);
   assert(_phys_page_alloc(phys_addr));
-  return phys_addr;
+
+  // Return HHDM address.
+  return VM_TO_HHDM(phys_addr);
 }
 
 void phys_page_free(void *pg) { assert(_phys_page_free(pg)); }


### PR DESCRIPTION
This fixes the `make limine` command on a new install. Fixing the submodule to a particular source commit is not enough for stability, because the `make limine` process downloads some files that may cause a build incompatibility. Thus, the Limine submodule (w/ VGA text mode changes) are rebased upon the v5.x trunk. The v5.x trunk also breaks the v4.x protocol by removing the direct map.