### PR TITLE
Thread scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ out*/
 
 # Emacs tempfiles
 *~
+
+# Misc.
+.gdb_history

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ ifneq ($(DEBUG),)
     override NASMFLAGS += -DDEBUG -g
     override OUT_DIR := $(OUT_DIR).debug
     ifeq ($(DEBUG),i)
-        override QEMUFLAGS += -s -S -no-reboot -no-shutdown
+        override QEMUFLAGS += -s -S -no-reboot -no-shutdown -d int
     endif
 endif
 

--- a/TODO.md
+++ b/TODO.md
@@ -20,11 +20,20 @@ This list will probably begin as a very generic list and become more and more fo
 - [ ] Terminal multiplexing (like GNU `screen`): multiplex a single terminal device for multiple processes
 
 ### Processes
-- [ ] Kernel threads
+- [X] Kernel threads
+- [ ] (Cooperative) scheduling
+- [ ] Timer interrupt/preemptive scheduling
 - [ ] Initial bootstrap from kernel mode into userspace
-- [ ] Userspace processes
-- [ ] Scheduling
-- [ ] Threads
+- [ ] Userspace threads/processes
+
+WIP: processes TODO:
+- Create convenience functions that use the default scheduler
+- Modify the shell to run things in a different thread.
+- Print process/thread tree
+- Clone() and fork()
+- Timer interrupt
+- Write some basic multithreaded programs
+- Next step: write some locking primitives (spinlock to start)
 
 ### Memory
 - Physical memory utilities:

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,7 @@ WIP: processes TODO:
 - Timer interrupt
 - Write some basic multithreaded programs
 - Next step: write some locking primitives (spinlock to start)
+- Backtrace
 
 ### Memory
 - Physical memory utilities:

--- a/TODO.md
+++ b/TODO.md
@@ -20,23 +20,28 @@ This list will probably begin as a very generic list and become more and more fo
 - [ ] Terminal multiplexing (like GNU `screen`): multiplex a single terminal device for multiple processes
 
 ### Processes
-- [X] Kernel threads
-- [ ] (Cooperative) scheduling
-- [ ] Timer interrupt/preemptive scheduling
-- [ ] Initial bootstrap from kernel mode into userspace
-- [ ] Userspace threads/processes
-
-WIP: processes TODO:
-- Create convenience functions that use the default scheduler
-- Modify the shell to run things in a different thread.
-- Print process/thread tree
-- Clone() and fork()
-- Timer interrupt
-- Write some basic multithreaded programs
-- Next step: write some locking primitives (spinlock to start)
-- Backtrace
+- [ ] Kernel thread scheduling
+  - [X] Kernel threads
+  - [X] (Cooperative) scheduling -- a `schedule()` function
+  - [X] Preemptive scheduling (via timer interrupt)
+- [ ] Userspace processes
+  - [ ] Initial bootstrap from kernel mode into userspace.
+    - [ ] Set up TSS
+    - [ ] Set up userspace stack.
+  - [ ] Syscall interface -- clone(), fork(), wait(), read(), write()
+  - [ ] Scheduler waitqueues for different events: wait on file.
+  - [ ] Userspace memory mapping/protection.
+- [ ] Backtrace
+- [ ] Locking primitives
+- [ ] Utilities
+  - [ ] Userspace shell
+  - [ ] Write some basic multithreaded programs
+  - [ ] ps and pstree
 
 ### Memory
+- Descriptor tables
+  - [ ] Set up custom GDT
+  - [X] Set up custom IDT
 - Physical memory utilities:
   - [X] struct page array
   - [X] Page allocator (round-robin)

--- a/src/kernel/arch/x86_64/interrupt.c
+++ b/src/kernel/arch/x86_64/interrupt.c
@@ -44,16 +44,17 @@ void create_interrupt_gate(struct gate_desc *gate_desc, void *isr) {
 
 void init_interrupts(void) {
   // https://forum.osdev.org/viewtopic.php?p=316295#p316295
-  outb(0x11, 0x20);
-  outb(0x11, 0xA0);
-  outb(0x20, 0x21);
-  outb(40, 0xA1);
-  outb(0x04, 0x21);
-  outb(0x02, 0xA1);
-  outb(0x01, 0x21);
-  outb(0x01, 0xA1);
-  outb(0xF8, 0x21);
-  outb(0xEF, 0xA1);
+  outb(0x11, 0x20); // initialize, pic1_cmd
+  outb(0x11, 0xA0); // initialize, pic2_cmd
+  outb(0x20, 0x21); // 32 (offset), pic1_data
+  outb(40, 0xA1);   // 40 (offset), pic2_data
+  outb(0x04, 0x21); // slave PIC at IRQ2, pic1_data
+  outb(0x02, 0xA1); // cascade identity, pic2_data
+  outb(0x01, 0x21); // 8086 mode, pic1_data
+  outb(0x01, 0xA1); // 8086 mode, pic2_data
+
+  outb(0xF8, 0x21); // 0b11111000 mask, pic1_data -- unmask irq 0, 1, 2
+  outb(0xEF, 0xA1); // 0b11101111 mask, pic2_data -- unmask irq 12
 
   load_idtr(&idtr);
 

--- a/src/kernel/arch/x86_64/interrupt.h
+++ b/src/kernel/arch/x86_64/interrupt.h
@@ -16,6 +16,16 @@ struct interrupt_frame {
   size_t ss;
 };
 
+// Exceptions have an additional error code pushed onto the stack.
+struct exception_frame {
+  size_t code;
+  size_t ip;
+  size_t cs;
+  size_t flags;
+  size_t sp;
+  size_t ss;
+};
+
 extern struct gate_desc gates[64];
 extern struct idtr_desc idtr;
 

--- a/src/kernel/common/list.c
+++ b/src/kernel/common/list.c
@@ -48,3 +48,12 @@ bool list_empty(struct list_head *ll) {
   assert(ll);
   return ll->next == ll;
 }
+
+size_t list_length(const struct list_head *ll) {
+  assert(ll);
+  assert(ll->next);
+
+  size_t rval = 0;
+  list_foreach_const(ll, _) { ++rval; }
+  return rval;
+}

--- a/src/kernel/common/list.h
+++ b/src/kernel/common/list.h
@@ -27,6 +27,7 @@
 #define COMMON_LIST_H
 
 #include <stdbool.h>
+#include <stddef.h>
 
 struct list_head {
   struct list_head *prev;
@@ -90,5 +91,10 @@ bool list_empty(struct list_head *ll);
  */
 #define list_foreach_const(ll, it)                                             \
   for (const struct list_head *(it) = (ll); ((it) = (it)->next) != (ll);)
+
+/**
+ * Get list length.
+ */
+size_t list_length(const struct list_head *ll);
 
 #endif // COMMON_LIST_H

--- a/src/kernel/diag/shell.c
+++ b/src/kernel/diag/shell.c
@@ -1,10 +1,13 @@
 #include "diag/shell.h"
 
+#include "arch/x86_64/interrupt.h"
 #include "common/libc.h"
+#include "common/util.h"
 #include "diag/mm.h"
 #include "drivers/console.h"
 #include "drivers/term.h"
 #include "mem/phys.h"
+#include "sched/sched.h"
 #include "test/test.h"
 
 #define SHELL_INPUT_BUF_SZ 4095
@@ -71,10 +74,48 @@ void _shell_handle_input(void) {
   _shell_input_size = 0;
 }
 
+/**
+ * Copied from https://wiki.osdev.org/8259_PIC. Can be used for diagnostics.
+ */
+#define PIC1_CMD 0x20
+#define PIC1_DATA 0x21
+#define PIC2_CMD 0xA0
+#define PIC2_DATA 0xA1
+#define PIC_READ_IRR 0x0a /* OCW3 irq ready next CMD read */
+#define PIC_READ_ISR 0x0b /* OCW3 irq service next CMD read */
+
+/* Helper func */
+static uint16_t __pic_get_irq_reg(int ocw3) {
+  /* OCW3 to PIC CMD to get the register values.  PIC2 is chained, and
+   * represents IRQs 8-15.  PIC1 is IRQs 0-7, with 2 being the chain */
+  outb(ocw3, PIC1_CMD);
+  outb(ocw3, PIC2_CMD);
+  return (((uint16_t)inb(PIC2_CMD)) << 8) | inb(PIC1_CMD);
+}
+
+/* Returns the combined value of the cascaded PICs irq request register */
+uint16_t pic_get_irr(void) { return __pic_get_irq_reg(PIC_READ_IRR); }
+
+/* Returns the combined value of the cascaded PICs in-service register */
+uint16_t pic_get_isr(void) { return __pic_get_irq_reg(PIC_READ_ISR); }
+
 void shell_init() {
+  // Need to re-enable interrupts once the task is created since we cli upon
+  // entering the scheduler.
+  //
+  // TODO(jlam): Move this to a helper function so we don't need this at the
+  // beginning of each thread.
+  __asm__ volatile("sti");
+
   _term_driver = get_default_term_driver();
   _shell_input_size = 0;
   _shell_prompt();
+
+  // Yield task; nothing to do for now.
+  for (;;) {
+    shell_on_interrupt();
+    schedule();
+  }
 }
 
 void shell_on_interrupt() {

--- a/src/kernel/diag/sys.c
+++ b/src/kernel/diag/sys.c
@@ -7,6 +7,8 @@
 #include "arch/x86_64/idt.h"
 #include "common/libc.h"
 
+// TODO(jlam): Remove this. Or move to a unit test (and probably use sprintf
+// rather than printf).
 void run_printf_tests(void) {
   // Run some printf tests.
   char buf[256];
@@ -23,16 +25,16 @@ void run_printf_tests(void) {
   };
   for (int i = 0, count = sizeof(ns) / sizeof(ns[0]); i < count; ++i) {
     int n = ns[i];
-    int len = printf("Testing\n"
-                     "%%d='%d'\n"
-                     "%%u='%u'\n"
-                     "%%o='%o'\n"
-                     "%%b='%b'\n"
-                     "%%x='%x'\n"
-                     "%%c='%c'\n"
-                     "%%s='%s'\n%s\n",
+    int len = printf("Testing\r\n"
+                     "%%d='%d'\r\n"
+                     "%%u='%u'\r\n"
+                     "%%o='%o'\r\n"
+                     "%%b='%b'\r\n"
+                     "%%x='%x'\r\n"
+                     "%%c='%c'\r\n"
+                     "%%s='%s'\r\n%s\r\n",
                      n, n, n, n, n, n, "hello", buf);
-    printf("got len=%d\n", len);
+    printf("got len=%d\r\n", len);
   }
 
   long ms[] = {
@@ -43,24 +45,25 @@ void run_printf_tests(void) {
   };
   for (int i = 0, count = sizeof(ms) / sizeof(ms[0]); i < count; ++i) {
     long m = ms[i];
-    int len = printf("Testing\n"
-                     "%%ld='%ld'\n"
-                     "%%lu='%lu'\n"
-                     "%%lo='%lo'\n"
-                     "%%lb='%lb'\n"
-                     "%%lx='%lx'\n"
-                     "%%s='%s'\n%s\n",
+    int len = printf("Testing\r\n"
+                     "%%ld='%ld'\r\n"
+                     "%%lu='%lu'\r\n"
+                     "%%lo='%lo'\r\n"
+                     "%%lb='%lb'\r\n"
+                     "%%lx='%lx'\r\n"
+                     "%%s='%s'\r\n%s\r\n",
                      m, m, m, m, m, "hello", buf);
-    printf("got len=%d\n", len);
+    printf("got len=%d\r\n", len);
   }
 
   char buf2[128];
   int len = snprintf(buf2, sizeof(buf2), buf);
-  printf("got len=%d\n", len);
-  len = printf("%s\n", buf2);
-  printf("got len=%d\n", len);
+  printf("got len=%d\r\n", len);
+  len = printf("%s\r\n", buf2);
+  printf("got len=%d\r\n", len);
 }
 
+// TODO(jlam): saa
 void print_gdtr_info(void) {
   struct gdtr_desc gdtr;
   struct segment_desc *seg_desc;
@@ -68,7 +71,7 @@ void print_gdtr_info(void) {
   size_t base, limit;
 
   read_gdt(&gdtr);
-  printf("gdtr {\n\t.sz=0x%hx\n\t.off=0x%lx\n}\n", gdtr.sz, gdtr.off);
+  printf("gdtr {\r\n\t.sz=0x%hx\r\n\t.off=0x%lx\r\n}\r\n", gdtr.sz, gdtr.off);
 
   // Read segment descriptors.
   num_entries = ((size_t)gdtr.sz + 1) / sizeof(*seg_desc);
@@ -82,24 +85,25 @@ void print_gdtr_info(void) {
     // Compute base.
     base = (size_t)seg_desc->base_3 << 24 | (size_t)seg_desc->base_2 << 16 |
            seg_desc->base_1;
-    printf("segment {\n"
-           "\t.limit=0x%lx\n"
-           "\t.base=0x%lx\n"
-           "\t.read_write=%d\n"
-           "\t.accessed=%d\n"
-           "\t.direction_conforming=%d\n"
-           "\t.executable=%d\n"
-           "\t.is_system=%d\n"
-           "\t.cpu_privilege=%d\n"
-           "\t.is_long_mode_code=%d\n"
-           "\t.is_32bit_protected_mode=%d\n"
-           "}\n",
+    printf("segment {\r\n"
+           "\t.limit=0x%lx\r\n"
+           "\t.base=0x%lx\r\n"
+           "\t.read_write=%d\r\n"
+           "\t.accessed=%d\r\n"
+           "\t.direction_conforming=%d\r\n"
+           "\t.executable=%d\r\n"
+           "\t.is_system=%d\r\n"
+           "\t.cpu_privilege=%d\r\n"
+           "\t.is_long_mode_code=%d\r\n"
+           "\t.is_32bit_protected_mode=%d\r\n"
+           "}\r\n",
            limit, base, seg_desc->access_rw, seg_desc->access_a,
            seg_desc->access_dc, seg_desc->access_e, seg_desc->access_s,
            seg_desc->access_dpl, seg_desc->flags_l, seg_desc->flags_db);
   }
 }
 
+// TODO(jlam): saa
 void print_idtr_info(void) {
   struct idtr_desc idtr;
   struct gate_desc *gate_desc;
@@ -107,7 +111,7 @@ void print_idtr_info(void) {
   size_t off;
 
   read_idt(&idtr);
-  printf("idtr {\n\t.sz=0x%hx\n\t.off=0x%lx\n}\n", idtr.sz, idtr.off);
+  printf("idtr {\r\n\t.sz=0x%hx\r\n\t.off=0x%lx\r\n}\r\n", idtr.sz, idtr.off);
 
   // Read segment descriptors.
   num_entries = ((size_t)idtr.sz + 1) / sizeof(*gate_desc);
@@ -115,13 +119,13 @@ void print_idtr_info(void) {
   for (; num_entries--; ++gate_desc) {
     off = (size_t)gate_desc->off_3 << 32 | (size_t)gate_desc->off_2 << 16 |
           gate_desc->off_1;
-    printf("gate {\n"
-           "\t.off=0x%lx\n"
-           "\t.ist=0x%lx\n"
-           "\t.gate_type=0x%x\n"
-           "\t.dpl=0x%x\n"
-           "\t.p=0x%x\n"
-           "}\n",
+    printf("gate {\r\n"
+           "\t.off=0x%lx\r\n"
+           "\t.ist=0x%lx\r\n"
+           "\t.gate_type=0x%x\r\n"
+           "\t.dpl=0x%x\r\n"
+           "\t.p=0x%x\r\n"
+           "}\r\n",
            off, gate_desc->ist, gate_desc->gate_type, gate_desc->dpl,
            gate_desc->p);
   }

--- a/src/kernel/mem/slab.c
+++ b/src/kernel/mem/slab.c
@@ -265,6 +265,9 @@ void *kmalloc(size_t sz) {
 
 void _slab_free(struct slab *slab, const void *obj) {
   // Find the position of the object in the freelist.
+  // - off: offset in bytes
+  // - index: offset in (# of elements)
+  // - i: position in stack
   const size_t off = obj - slab->data;
   const unsigned order = slab->parent->order;
 
@@ -276,7 +279,7 @@ void _slab_free(struct slab *slab, const void *obj) {
   assert(index < slab->parent->elements);
   const uint8_t i = slab->freelist[index].pos_in_stk;
 
-  // Free the element 0. Beforehand:
+  // Free the element at index 0. Beforehand:
   //
   //          used   |  free
   //     | 0 | 2 | 3 | 4 | 1 | stack_item
@@ -292,7 +295,7 @@ void _slab_free(struct slab *slab, const void *obj) {
   slab->freelist[i].stack_item = slab->freelist[slab->allocated].stack_item;
   slab->freelist[slab->allocated].stack_item = index;
 
-  slab->freelist[i].pos_in_stk = slab->allocated;
+  slab->freelist[index].pos_in_stk = slab->allocated;
   slab->freelist[slab->freelist[i].stack_item].pos_in_stk = i;
 }
 

--- a/src/kernel/sched/sched.c
+++ b/src/kernel/sched/sched.c
@@ -1,0 +1,113 @@
+#include "sched/sched.h"
+
+#include <assert.h>
+
+#include "common/list.h"
+#include "mem/slab.h"
+
+void sched_init(struct scheduler *scheduler) {
+  list_init(&scheduler->runnable);
+  list_init(&scheduler->blocked);
+
+  // No idle task.
+  scheduler->current_task = NULL;
+}
+
+struct sched_task *sched_create_task(struct scheduler *scheduler,
+                                     void (*cb)(struct sched_task *)) {
+  // TODO(jlam55555): Allow specifying the allocator.
+  // Actually, better yet to not allocate. Let the caller allocate.
+  struct sched_task *task = kmalloc(sizeof(struct sched_task));
+  if (!task) {
+    return task;
+  }
+
+  // TODO(jlam55555): Set up stack by pushing fake registers.
+
+  task->parent = scheduler;
+  task->state = SCHED_RUNNABLE;
+  task->ip = cb;
+  list_add(&scheduler->runnable, &task->ll);
+  return task;
+}
+
+void sched_bootstrap_task(struct scheduler *scheduler) {
+  struct sched_task *task = sched_create_task(scheduler, NULL);
+
+  // `sched_task_switch_nostack()` has special handling for the initial
+  // "bootstrap" call, where there is no current task.
+  sched_task_switch_nostack(task);
+}
+
+void sched_task_destroy(struct sched_task *task) {
+  assert(task->parent);
+
+  list_del(&task->ll);
+
+  // If this is the running process, schedule away.
+  //
+  // TODO(jlam55555): The interfaces here are a bit wonky.
+  if (task->parent->current_task == task) {
+    sched_task_switch(sched_choose_task(task->parent));
+  }
+
+  kfree(task);
+}
+
+struct sched_task *sched_choose_task(struct scheduler *scheduler) {
+  if (!list_empty(&scheduler->runnable)) {
+    return list_entry(scheduler->runnable.next, struct sched_task, ll);
+  }
+
+  assert(scheduler->current_task);
+  return scheduler->current_task;
+}
+
+void sched_task_switch(struct sched_task *task) {
+  assert(task);
+  struct sched_task *old_task = task->parent->current_task;
+
+  // Switch to self, nothing to do here.
+  if (task == old_task) {
+    return;
+  }
+
+  sched_task_switch_nostack(task);
+
+  // TODO(jlam55555): Save context on previous task.
+
+  // TODO(jlam55555): Restore context on new task.
+
+  // TODO(jlam55555): This is not written atomically/reentrant. Need a spinlock
+  // to protect this critical section.
+}
+
+void sched_task_switch_nostack(struct sched_task *task) {
+  if (task->state == SCHED_RUNNING) {
+    // Nothing to do.
+    return;
+  }
+
+  assert(task->state != SCHED_BLOCKED);
+
+  struct scheduler *scheduler = task->parent;
+  struct sched_task *old_task = scheduler->current_task;
+
+  // Clean up the old task. It can be null during the bootstrap process.
+  // TODO(jlam55555): `likely()`.
+  if (old_task) {
+    list_add(&scheduler->runnable, &old_task->ll);
+    if (old_task->state == SCHED_RUNNING) {
+      // If the old task was timer-preempted (it wasn't scheduled away due to
+      // blocking), then set it to runnable.
+      old_task->state = SCHED_RUNNABLE;
+    }
+  }
+
+  // Set up the new task.
+  list_del(&task->ll);
+  task->state = SCHED_RUNNING;
+
+  // Adjust scheduler state.
+  scheduler->current_task = task;
+}

--- a/src/kernel/sched/sched.c
+++ b/src/kernel/sched/sched.c
@@ -48,7 +48,8 @@ struct sched_task *sched_create_task(struct scheduler *scheduler,
 
   task->parent = scheduler;
   task->state = SCHED_RUNNABLE;
-  list_add(&scheduler->runnable, &task->ll);
+  // Add to tail (queue) for round-robin scheduling.
+  list_add_tail(&scheduler->runnable, &task->ll);
   return task;
 }
 
@@ -62,21 +63,44 @@ void sched_bootstrap_task(struct scheduler *scheduler) {
   sched_task_switch_nostack(task);
 }
 
+/**
+ * Bottom-half of the task switch mechanism. Implemented in pure asm so we don't
+ * accidentally clobber registers.
+ */
+void _sched_task_switch_stack(void *old_stk, void *new_stk);
+
 void sched_task_destroy(struct sched_task *task) {
   assert(task->parent);
 
-  list_del(&task->ll);
-
-  // If this is the running process, schedule away.
-  //
-  // TODO(jlam55555): The interfaces here are a bit wonky.
+  // If this is the running process, schedule away (Top half).
+  struct sched_task *new_task = NULL;
   if (task->parent->current_task == task) {
-    sched_task_switch(sched_choose_task(task->parent));
+    new_task = sched_choose_task(task->parent);
+
+    // If this assertion fails, it means that we are trying to switch back to
+    // the same thread. Which means that there are no runnable threads, which is
+    // an error because there should always be one (e.g., the idle thread).
+    // Alternatively, we could manually check if the runnable list is empty.
+    assert(new_task != task);
+
+    sched_task_switch_nostack(new_task);
   }
+
+  // The task should now either be runnable or blocked. (It shouldn't be running
+  // because of `sched_task_switch_nostack()`).
+  list_del(&task->ll);
 
   // Free the stack. This assumes we didn't overflow the stack.
   phys_free_page(PG_FLOOR(task->stk));
   kfree(task);
+
+  // If this is the running process, actually schedule away (Bottom half).
+  // We break it up like this so we can do cleanup tasks between the top half
+  // and bottom half.
+  if (new_task) {
+    void *unused;
+    _sched_task_switch_stack(&unused, new_task->stk);
+  }
 }
 
 struct sched_task *sched_choose_task(struct scheduler *scheduler) {
@@ -87,12 +111,6 @@ struct sched_task *sched_choose_task(struct scheduler *scheduler) {
   assert(scheduler->current_task);
   return scheduler->current_task;
 }
-
-/**
- * Bottom-half of the task switch mechanism. Implemented in pure asm so we don't
- * accidentally clobber registers.
- */
-void _sched_task_switch_stack(void *old_stk, void *new_stk);
 
 void sched_task_switch(struct sched_task *task) {
   assert(task);
@@ -124,7 +142,8 @@ void sched_task_switch_nostack(struct sched_task *task) {
   // Clean up the old task. It can be null during the bootstrap process.
   // TODO(jlam55555): `likely()`.
   if (old_task) {
-    list_add(&scheduler->runnable, &old_task->ll);
+    // Add to tail (queue) for round-robin scheduling.
+    list_add_tail(&scheduler->runnable, &old_task->ll);
     if (old_task->state == SCHED_RUNNING) {
       // If the old task was timer-preempted (it wasn't scheduled away due to
       // blocking), then set it to runnable.

--- a/src/kernel/sched/sched.h
+++ b/src/kernel/sched/sched.h
@@ -21,6 +21,10 @@ struct scheduler {
   struct sched_task *current_task;
 };
 
+/**
+ * TODO(jlam55555): Document this.
+ * TODO(jlam55555): Allow tasks to have a desc/name.
+ */
 struct sched_task {
   struct list_head ll;
   struct scheduler *parent;

--- a/src/kernel/sched/sched.h
+++ b/src/kernel/sched/sched.h
@@ -54,6 +54,10 @@ void sched_init(struct scheduler *scheduler);
 
 /**
  * Creates a task in the given scheduler.
+ *
+ * Note that the scheduler manages allocation rather than accepting a `struct
+ * sched_task *`. This is so that the scheduler also manages the destruction/
+ * freeing of all tasks.
  */
 struct sched_task *sched_create_task(struct scheduler *scheduler,
                                      void (*cb)(struct sched_task *));
@@ -73,13 +77,15 @@ void sched_task_destroy_nostack(struct sched_task *task);
 /**
  * Destroy task. If this is the current task in the scheduler, then schedule
  * away.
+ *
+ * Note that the destroyed task will be freed, so you cannot use it afterwards.
  */
 void sched_task_destroy(struct sched_task *task);
 
 /**
  * Choose the next task to schedule (but don't actually schedule). Behavior:
  *
- * - If the runnable queue is not empty, return any task on it.
+ * - If the runnable queue is not empty, return the first task on it.
  * - Return the current task.
  *
  * Note that the current task shouldn't be blocked. It's an error if it is,

--- a/src/kernel/sched/sched.h
+++ b/src/kernel/sched/sched.h
@@ -1,13 +1,74 @@
 /**
- * Very simple round-robin task scheduler.
+ * Very simple round-robin task scheduler for kernel threads. This does not have
+ * any userspace thread/process semantics.
  *
- * TODO(jlam55555): Set up unit tests.
- * TODO(jlam55555): Set up quanta.
- * TODO(jlam55555): Document idle task.
- * TODO(jlam55555): Document scheduler "valid" state. Only after calling
- * `sched_task_switch_nostack()` for the first time will there be a current task
- * in a scheduler. Similarly, after calling `sched_destroy()` there will be no
- * more tasks on this scheduler.
+ * Each task ("thread") has its own stack, instruction pointer (implicitly
+ * stored on the stack when scheduling away), and no memory protections. A
+ * scheduler will have exactly one task scheduled (running) at a time (after the
+ * bootstrap process and before destruction).
+ *
+ * To perform scheduling, you must first initialize a scheduler object. Tasks
+ * can be added to this scheduler (either via `sched_clone_task()` or
+ * `sched_create_task()`, which are like Linux's `clone()` and `exec*()`
+ * syscalls, respectively). Tasks can be scheduled using `sched_choose_task()`
+ * and `sched_task_switch()`.
+ *
+ * In general, you will not need to worry about creating a scheduler object, the
+ * idle task, or bootstrapping process -- the interfaces to initialize a
+ * scheduler are mostly for unit testing. There is a global main task scheduler
+ * which all scheduling operations are implied to act on.
+ *
+ * This kernel uses pre-emptive scheduling. I.e., the timer interrupt will force
+ * a process to call `schedule()` if it has exceeded its quantum.
+ *
+ * TODO(jlam55555): Set up quanta/pre-emptive scheduling.
+ * TODO(jlam55555): Set up global main scheduler.
+ * TODO(jlam55555): Implement `clone()` API.
+ *
+ * =============================================================================
+ * Bootstrapping process
+ * =============================================================================
+ * There is some special handling around entering the scheduler for the first
+ * time -- this is called the "bootstrapping process". There are two ways to do
+ * this. Calling `sched_task_switch(_nostack)()` for the first time will
+ * automatically bootstrap the given thread if there were no previously running
+ * tasks. However, doing so will also discard the current stack, which may be
+ * undesirable -- thus, the helper function `sched_bootstrap_task()` is provided
+ * to form an `exec*()`-like interface to enter the scheduler for the first
+ * time. This is used in the global main task scheduler.
+ *
+ * Bootstrapping a scheduler when another one is already running, or destroying
+ * a bootstrapped scheduler are both UB -- we expect that there is exactly one
+ * kernel-level task scheduler that persists the entire lifetime of the
+ * operating system once it has bootstrapped. (This is not the case for unit
+ * tests, which use a pseudo-bootstrapping process. This may also change in the
+ * future if scheduling needs become more complicated.)
+ *
+ * =============================================================================
+ * Idle task
+ * =============================================================================
+ * In general, the round-robin scheduler chooses the first task on the runnable
+ * queue to schedule. If not, then it'll choose the previously-running task, if
+ * it is not in a blocked state (i.e., it was pre-empted). But what if there are
+ * no runnable tasks and the previously-running task is blocked?
+ *
+ * This motivates an idle task, which is a regular task with some special
+ * properties: it always exists and is always runnable/running (never blocked).
+ * It will thus be the target for scheduling if no other task is schedulable.
+ * Like a sentinel node, this more cleanly handles this edge case than trying to
+ * write the logic to manually wait for a task to be schedulable.
+ *
+ * The idle task is not provided by the scheduler -- the implementor must create
+ * the idle task. Here is an example of how to bootstrap into the scheduler with
+ * an idle task:
+ *
+ * ```
+ * static void _idle_task(void) { for (;;) { __asm__("hlt"); } }
+ * ...
+ * struct scheduler scheduler;
+ * sched_add_task(&scheduler, _idle_task);
+ * sched_bootstrap_task(&scheduler);
+ * ```
  */
 #ifndef SCHED_SCHED_H
 #define SCHED_SCHED_H
@@ -15,7 +76,7 @@
 #include "common/list.h"
 
 /**
- * Round-robin scheduler.
+ * Round-robin task scheduler.
  */
 struct sched_task;
 struct scheduler {
@@ -26,8 +87,9 @@ struct scheduler {
 };
 
 /**
- * TODO(jlam55555): Document this.
- * TODO(jlam55555): Allow tasks to have a desc/name.
+ * A kernel thread.
+ *
+ * TODO(jlam55555): Allow threads to have a name.
  */
 struct sched_task {
   struct list_head ll;

--- a/src/kernel/sched/sched.h
+++ b/src/kernel/sched/sched.h
@@ -1,0 +1,69 @@
+/**
+ * Very simple round-robin task scheduler.
+ *
+ * TODO(jlam55555): Set up unit tests.
+ * TODO(jlam55555): Set up quanta.
+ * TODO(jlam55555): Document idle task.
+ */
+#ifndef SCHED_SCHED_H
+#define SCHED_SCHED_H
+
+#include "common/list.h"
+
+/**
+ * Round-robin scheduler.
+ */
+struct sched_task;
+struct scheduler {
+  struct list_head running;
+  struct list_head runnable;
+  struct list_head blocked;
+
+  struct sched_task *current_task;
+};
+
+struct sched_task {
+  struct list_head *ll;
+  struct scheduler *parent;
+  void *stk;
+};
+
+/**
+ * Creates a task in the given scheduler.
+ */
+struct task *sched_create_task(struct scheduler *scheduler);
+
+/**
+ * Destroy task. If this is the current task in the scheduler, then schedule
+ * away.
+ */
+struct sched_task_destroy(struct sched_task *task);
+
+/**
+ * Choose the next task to schedule (but don't actually schedule). Behavior:
+ *
+ * - If the runnable queue is not empty, return any task on it.
+ * - Return the current task.
+ *
+ * Note that the current task shouldn't be blocked. It's an error if it is,
+ * because there should always be an "idle" task that is always
+ * running/runnable (never blocked).
+ */
+struct task *sched_choose_task(struct scheduler *scheduler);
+
+/**
+ * Switch to the given task. This comprises of a few steps:
+ *
+ * If the task is already running, nothing to do.
+ *
+ * If the task is not already running:
+ * - Make sure the given task is not blocked or running (it must be runnable).
+ * - If the currently-running task is running (i.e., not blocked), set it to
+ *   runnable. (We pre-empt it.)
+ * - Save the state of the previous task onto its stack.
+ * - Set the scheduled task to running.
+ * - Restore the stack of the given task.
+ */
+struct task *sched_task_switch(struct sched_task *task);
+
+#endif // SCHED_SCHED_H

--- a/src/kernel/sched/sched.h
+++ b/src/kernel/sched/sched.h
@@ -15,7 +15,6 @@
  */
 struct sched_task;
 struct scheduler {
-  struct list_head running;
   struct list_head runnable;
   struct list_head blocked;
 
@@ -23,21 +22,46 @@ struct scheduler {
 };
 
 struct sched_task {
-  struct list_head *ll;
+  struct list_head ll;
   struct scheduler *parent;
+  void *ip;
   void *stk;
+  enum sched_task_state {
+    SCHED_RUNNING,
+    SCHED_RUNNABLE,
+    SCHED_BLOCKED,
+  } state;
 };
+
+/**
+ * Initialize scheduler. Note that no idle task is created, you have to create
+ * one yourself.
+ *
+ * To enter the scheduler, you need to do two things:
+ *
+ * 1. Create an idle task.
+ * 2. Mark the current task as part of the scheduler using
+ *    `sched_bootstrap_task()`.
+ */
+void sched_init(struct scheduler *scheduler);
 
 /**
  * Creates a task in the given scheduler.
  */
-struct task *sched_create_task(struct scheduler *scheduler);
+struct sched_task *sched_create_task(struct scheduler *scheduler,
+                                     void (*cb)(struct sched_task *));
+
+/**
+ * Add the current thread to the given scheduler. This is used for the
+ * bootstrapping process, and should be called exactly once.
+ */
+void sched_bootstrap_task(struct scheduler *scheduler);
 
 /**
  * Destroy task. If this is the current task in the scheduler, then schedule
  * away.
  */
-struct sched_task_destroy(struct sched_task *task);
+void sched_task_destroy(struct sched_task *task);
 
 /**
  * Choose the next task to schedule (but don't actually schedule). Behavior:
@@ -49,7 +73,7 @@ struct sched_task_destroy(struct sched_task *task);
  * because there should always be an "idle" task that is always
  * running/runnable (never blocked).
  */
-struct task *sched_choose_task(struct scheduler *scheduler);
+struct sched_task *sched_choose_task(struct scheduler *scheduler);
 
 /**
  * Switch to the given task. This comprises of a few steps:
@@ -63,7 +87,19 @@ struct task *sched_choose_task(struct scheduler *scheduler);
  * - Save the state of the previous task onto its stack.
  * - Set the scheduled task to running.
  * - Restore the stack of the given task.
+ * - Jump to the new instruction pointer.
  */
-struct task *sched_task_switch(struct sched_task *task);
+void sched_task_switch(struct sched_task *task);
+
+/**
+ * Similar to `sched_task_switch()`, but don't switch stacks or jump instruction
+ * pointer -- this is basically the bookkeeping part of task switching. This is
+ * useful for unit-testing the scheduler and as a building block in
+ * `sched_task_switch()`.
+ *
+ * This has special behavior for the initial "bootstrap" call, in which there is
+ * no old task to be torn down.
+ */
+void sched_task_switch_nostack(struct sched_task *task);
 
 #endif // SCHED_SCHED_H

--- a/src/kernel/sched/sched.h
+++ b/src/kernel/sched/sched.h
@@ -4,6 +4,10 @@
  * TODO(jlam55555): Set up unit tests.
  * TODO(jlam55555): Set up quanta.
  * TODO(jlam55555): Document idle task.
+ * TODO(jlam55555): Document scheduler "valid" state. Only after calling
+ * `sched_task_switch_nostack()` for the first time will there be a current task
+ * in a scheduler. Similarly, after calling `sched_destroy()` there will be no
+ * more tasks on this scheduler.
  */
 #ifndef SCHED_SCHED_H
 #define SCHED_SCHED_H
@@ -61,6 +65,12 @@ struct sched_task *sched_create_task(struct scheduler *scheduler,
 void sched_bootstrap_task(struct scheduler *scheduler);
 
 /**
+ * Top half of `sched_task_destroy()`. Doesn't switch stacks. Exposed for unit
+ * testing.
+ */
+void sched_task_destroy_nostack(struct sched_task *task);
+
+/**
  * Destroy task. If this is the current task in the scheduler, then schedule
  * away.
  */
@@ -104,5 +114,13 @@ void sched_task_switch(struct sched_task *task);
  * no old task to be torn down.
  */
 void sched_task_switch_nostack(struct sched_task *task);
+
+/**
+ * Tear down a scheduler and all tasks associated with it.
+ *
+ * Note that if those tasks allocated any memory, those are not tracked and
+ * would not be freed.
+ */
+void sched_destroy(struct scheduler *scheduler);
 
 #endif // SCHED_SCHED_H

--- a/src/kernel/sched/sched.h
+++ b/src/kernel/sched/sched.h
@@ -24,7 +24,6 @@ struct scheduler {
 struct sched_task {
   struct list_head ll;
   struct scheduler *parent;
-  void *ip;
   void *stk;
   enum sched_task_state {
     SCHED_RUNNING,

--- a/src/kernel/sched/sched_.S
+++ b/src/kernel/sched/sched_.S
@@ -1,0 +1,29 @@
+        .text
+        // void _sched_task_switch_stack(void **old_stk, void *new_stk);
+        .globl _sched_task_switch_stack
+_sched_task_switch_stack:
+        // Save callee-save registers.
+        push %rbp
+        push %rbx
+        push %r12
+        push %r13
+        push %r14
+        push %r15
+
+        // Save stack.
+        mov %rsp, (%rdi)
+
+        // The stack of a suspended or new task (created with
+        // `sched_task_create()`) must look like the stack is at this point.
+
+        // Restore stack.
+        mov %rsi, %rsp
+
+        // Restore callee-save registers.
+        pop %r15
+        pop %r14
+        pop %r13
+        pop %r12
+        pop %rbx
+        pop %rbp
+        ret

--- a/src/kernel/test/sched_test.c
+++ b/src/kernel/test/sched_test.c
@@ -6,24 +6,52 @@
 struct scheduler scheduler;
 
 void init_fn() {
-  for (int i = 0; i < 10; ++i) {
-    printf("Thread 2: %d Running in a thread!\n", i);
+  for (int i = 0; i < 5; ++i) {
+    // TODO(jlam55555): This printing is not very intuitive because all these
+    // threads have the same printing. Need threads to distinguish themselves
+    // somehow, e.g., a name.
+    printf("Thread 2: %d Running in a thread!\r\n", i);
     sched_task_switch(sched_choose_task(&scheduler));
   }
 
   sched_task_destroy(scheduler.current_task);
 }
 
+/**
+ * Simple cooperative threading.
+ *
+ * TODO(jlam55555): May not be cooperative after preemption is enabled on timer
+ * interrupt. Will probably need to disable interrupts for that.
+ */
 DEFINE_TEST(sched, coroutines) {
+  // TODO(jlam55555): This is okay as a standalone test, but there is no way to
+  // "get out of the scheduler" yet, in the same way that initializing virtual
+  // memory is a one-way process. Also, we cannot virtualize scheduling within
+  // scheduling easily. So we need a way of isolating this test. Note also that
+  // `sched_task_destroy()` always calls the bottom half scheduler, whereas we
+  // can manually call just the top-half `sched_task_switch_nostack()`. We
+  // should make this test only call the top-half schedulers and not do the
+  // bootstrapping. It's probably pretty hard to unit test the bootstrapping or
+  // the bottom half (non-bookkeeping) in general.
+  //
+  // TODO(jlam55555): This test also tests multiple things at the moment, such
+  // as coroutines and scheduling itself when there are no other runnable
+  // processes.
   sched_init(&scheduler);
 
-  sched_create_task(&scheduler, init_fn);
+  for (int i = 0; i < 5; ++i) {
+    sched_create_task(&scheduler, init_fn);
+  }
   sched_bootstrap_task(&scheduler);
 
   for (int i = 0; i < 10; ++i) {
-    printf("Thread 1: %d Running in a thread!\n", i);
+    printf("Thread 1: %d Running in a thread!\r\n", i);
     sched_task_switch(sched_choose_task(&scheduler));
   }
+
+  // Trying to destroy the last task will fail.
+  //
+  // sched_task_destroy(scheduler.current_task);
 
   TEST_ASSERT(true);
 }

--- a/src/kernel/test/sched_test.c
+++ b/src/kernel/test/sched_test.c
@@ -3,55 +3,31 @@
 #include "common/libc.h"
 #include "test/test.h"
 
-struct scheduler scheduler;
+DEFINE_TEST(sched, lifecycle) {
+  struct scheduler scheduler;
 
-void init_fn() {
-  for (int i = 0; i < 5; ++i) {
-    // TODO(jlam55555): This printing is not very intuitive because all these
-    // threads have the same printing. Need threads to distinguish themselves
-    // somehow, e.g., a name.
-    printf("Thread 2: %d Running in a thread!\r\n", i);
-    sched_task_switch(sched_choose_task(&scheduler));
-  }
-
-  sched_task_destroy(scheduler.current_task);
-}
-
-/**
- * Simple cooperative threading.
- *
- * TODO(jlam55555): May not be cooperative after preemption is enabled on timer
- * interrupt. Will probably need to disable interrupts for that.
- */
-DEFINE_TEST(sched, coroutines) {
-  // TODO(jlam55555): This is okay as a standalone test, but there is no way to
-  // "get out of the scheduler" yet, in the same way that initializing virtual
-  // memory is a one-way process. Also, we cannot virtualize scheduling within
-  // scheduling easily. So we need a way of isolating this test. Note also that
-  // `sched_task_destroy()` always calls the bottom half scheduler, whereas we
-  // can manually call just the top-half `sched_task_switch_nostack()`. We
-  // should make this test only call the top-half schedulers and not do the
-  // bootstrapping. It's probably pretty hard to unit test the bootstrapping or
-  // the bottom half (non-bookkeeping) in general.
-  //
-  // TODO(jlam55555): This test also tests multiple things at the moment, such
-  // as coroutines and scheduling itself when there are no other runnable
-  // processes.
   sched_init(&scheduler);
 
-  for (int i = 0; i < 5; ++i) {
-    sched_create_task(&scheduler, init_fn);
-  }
-  sched_bootstrap_task(&scheduler);
+  // Shouldn't be any active task yet.
+  TEST_ASSERT(!scheduler.current_task);
 
+  // Create some tasks.
+  struct sched_task *tasks[10];
   for (int i = 0; i < 10; ++i) {
-    printf("Thread 1: %d Running in a thread!\r\n", i);
-    sched_task_switch(sched_choose_task(&scheduler));
+    tasks[i] = sched_create_task(&scheduler, NULL);
   }
 
-  // Trying to destroy the last task will fail.
-  //
-  // sched_task_destroy(scheduler.current_task);
+  // Start a task.
+  TEST_ASSERT(!scheduler.current_task);
+  sched_task_switch_nostack(tasks[0]);
+  TEST_ASSERT(scheduler.current_task);
 
-  TEST_ASSERT(true);
+  // Do some task switching.
+  for (int i = 9; i >= 0; --i) {
+    sched_task_switch_nostack(tasks[i]);
+  }
+
+  TEST_ASSERT(scheduler.current_task);
+  sched_destroy(&scheduler);
+  TEST_ASSERT(!scheduler.current_task);
 }

--- a/src/kernel/test/sched_test.c
+++ b/src/kernel/test/sched_test.c
@@ -1,20 +1,26 @@
 #include "sched/sched.h"
 
-#include "common/libc.h"
+#include "common/list.h"
 #include "test/test.h"
 
+/**
+ * Test basic lifecycle, including startup and destroyed state (`sched_init()`
+ * and `sched_destroy()`).
+ */
 DEFINE_TEST(sched, lifecycle) {
   struct scheduler scheduler;
 
   sched_init(&scheduler);
 
-  // Shouldn't be any active task yet.
+  // Initial state.
+  TEST_ASSERT(list_empty(&scheduler.runnable));
+  TEST_ASSERT(list_empty(&scheduler.blocked));
   TEST_ASSERT(!scheduler.current_task);
 
   // Create some tasks.
   struct sched_task *tasks[10];
   for (int i = 0; i < 10; ++i) {
-    tasks[i] = sched_create_task(&scheduler, NULL);
+    TEST_ASSERT(tasks[i] = sched_create_task(&scheduler, NULL));
   }
 
   // Start a task.
@@ -27,7 +33,204 @@ DEFINE_TEST(sched, lifecycle) {
     sched_task_switch_nostack(tasks[i]);
   }
 
-  TEST_ASSERT(scheduler.current_task);
+  /* TEST_ASSERT(scheduler.current_task); */
   sched_destroy(&scheduler);
+
+  // Destroyed state.
   TEST_ASSERT(!scheduler.current_task);
+  TEST_ASSERT(list_empty(&scheduler.runnable));
+  TEST_ASSERT(list_empty(&scheduler.blocked));
+}
+
+/**
+ * Test task selection.
+ */
+DEFINE_TEST(sched, choose_task) {
+  struct scheduler scheduler;
+  sched_init(&scheduler);
+
+  struct sched_task *task1, *task2;
+  TEST_ASSERT(task1 = sched_create_task(&scheduler, NULL));
+  TEST_ASSERT(task2 = sched_create_task(&scheduler, NULL));
+
+  // Set task1 as initial task. (Bootstrap process.)
+  sched_task_switch_nostack(task1);
+  TEST_ASSERT(scheduler.current_task == task1);
+
+  // Choose a new task. It should select task2 since it's runnable.
+  TEST_ASSERT(sched_choose_task(&scheduler) == task2);
+
+  // Choose a new task when there are no runnable tasks available. It should
+  // choose the current (running) task.
+  sched_task_destroy_nostack(task2);
+  TEST_ASSERT(sched_choose_task(&scheduler) == task1);
+
+  sched_destroy(&scheduler);
+}
+
+/**
+ * Test that task selection is round-robin when there are multiple runnable
+ * tasks.
+ */
+DEFINE_TEST(sched, choose_task_rr) {
+  struct scheduler scheduler;
+  sched_init(&scheduler);
+
+  // Create N tasks.
+  struct sched_task *tasks[4], *next_task;
+  for (int i = 0; i < 4; ++i) {
+    TEST_ASSERT(tasks[i] = sched_create_task(&scheduler, NULL));
+  }
+
+  // Schedule tasks in some arbitrary order.
+  sched_task_switch_nostack(tasks[3]);
+  sched_task_switch_nostack(tasks[1]);
+  sched_task_switch_nostack(tasks[0]);
+  sched_task_switch_nostack(tasks[2]);
+
+  // Schedule N times using `sched_choose_task()`. Make sure they appear in the
+  // same order.
+  //
+  // running task
+  // |
+  // |   runnable tasks
+  // v   v
+  // 2 | 3 1 0
+  // 3 | 1 0 2
+  // 1 | 0 2 3
+  // 0 | 2 3 1
+  // 2 | 3 1 0
+  // 3 | 1 0 2
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[3]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[1]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[0]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[2]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[3]);
+  sched_task_switch_nostack(next_task);
+
+  // Throw some additions/deletions into the mix.
+  //
+  // 3 | 0 2
+  // 0 | 2 3
+  // 2 | 3 0
+  // 3 | 0 2
+  // 0 | 2 3
+  // 2 | 3 0
+  sched_task_destroy_nostack(tasks[1]);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[0]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[2]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[3]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[0]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[2]);
+  sched_task_switch_nostack(next_task);
+
+  // 2 | 3 0 1
+  // 3 | 0 1 2
+  // 1 | 2 3 0
+  // 2 | 3 0 1
+  // 3 | 0 1 2
+  tasks[1] = sched_create_task(&scheduler, NULL);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[3]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[0]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[1]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[2]);
+  sched_task_switch_nostack(next_task);
+  TEST_ASSERT((next_task = sched_choose_task(&scheduler)) == tasks[3]);
+
+  sched_destroy(&scheduler);
+}
+
+/**
+ * Test task switching. (This doesn't test the actual stack switching, which is
+ * a bit hard to test, so the _nostack() version is used here. This means we
+ * only test the bookkeeping part of the task switching.)
+ */
+DEFINE_TEST(sched, task_switch) {
+  struct scheduler scheduler;
+  sched_init(&scheduler);
+
+  struct sched_task *task1, *task2;
+  TEST_ASSERT(task1 = sched_create_task(&scheduler, NULL));
+  TEST_ASSERT(task2 = sched_create_task(&scheduler, NULL));
+
+  // Initial state.
+  TEST_ASSERT(task1->state != SCHED_RUNNING);
+  TEST_ASSERT(scheduler.current_task != task1);
+  TEST_ASSERT(task2->state != SCHED_RUNNING);
+  TEST_ASSERT(scheduler.current_task != task2);
+
+  // Initial bootstrap to task1.
+  sched_task_switch_nostack(task1);
+  TEST_ASSERT(task1->state == SCHED_RUNNING);
+  TEST_ASSERT(scheduler.current_task == task1);
+  TEST_ASSERT(task2->state != SCHED_RUNNING);
+  TEST_ASSERT(scheduler.current_task != task2);
+
+  // Switch to a different (runnable) task.
+  sched_task_switch_nostack(task2);
+  TEST_ASSERT(task1->state != SCHED_RUNNING);
+  TEST_ASSERT(scheduler.current_task != task1);
+  TEST_ASSERT(task2->state == SCHED_RUNNING);
+  TEST_ASSERT(scheduler.current_task == task2);
+
+  // Switch to same (runnable) task. This should be a no-op/idempotent.
+  sched_task_switch_nostack(task2);
+  TEST_ASSERT(task1->state != SCHED_RUNNING);
+  TEST_ASSERT(scheduler.current_task != task1);
+  TEST_ASSERT(task2->state == SCHED_RUNNING);
+  TEST_ASSERT(scheduler.current_task == task2);
+
+  sched_destroy(&scheduler);
+}
+
+/**
+ * Similar to the above, we only test the bookkeeping side of things by using
+ * the _nostack() variant. (This means that we won't switch stacks if the
+ * current running task is destroyed.)
+ *
+ * Note that we cannot do any assertions on the deleted task because it will
+ * have been freed by the scheduler.
+ */
+DEFINE_TEST(sched, task_destroy) {
+  struct scheduler scheduler;
+  sched_init(&scheduler);
+
+  struct sched_task *task1, *task2, *task3;
+  TEST_ASSERT(task1 = sched_create_task(&scheduler, NULL));
+  TEST_ASSERT(task2 = sched_create_task(&scheduler, NULL));
+  TEST_ASSERT(task3 = sched_create_task(&scheduler, NULL));
+
+  sched_task_switch_nostack(task1);
+  TEST_ASSERT(scheduler.current_task == task1);
+  TEST_ASSERT(task1->state == SCHED_RUNNING);
+  TEST_ASSERT(task2->state == SCHED_RUNNABLE);
+  TEST_ASSERT(task3->state == SCHED_RUNNABLE);
+
+  // Delete a task that is not running.
+  sched_task_destroy_nostack(task2);
+  TEST_ASSERT(scheduler.current_task == task1);
+  TEST_ASSERT(task1->state == SCHED_RUNNING);
+  TEST_ASSERT(task3->state == SCHED_RUNNABLE);
+
+  // Delete the running task. See that we've switched away to a runnable task.
+  sched_task_destroy_nostack(task1);
+  TEST_ASSERT(scheduler.current_task == task3);
+  TEST_ASSERT(task3->state == SCHED_RUNNING);
+
+  // See that we have no other runnable tasks remaining since we've deleted
+  // them.
+  TEST_ASSERT(list_empty(&scheduler.runnable));
+
+  sched_destroy(&scheduler);
 }

--- a/src/kernel/test/sched_test.c
+++ b/src/kernel/test/sched_test.c
@@ -1,0 +1,29 @@
+#include "sched/sched.h"
+
+#include "common/libc.h"
+#include "test/test.h"
+
+struct scheduler scheduler;
+
+void init_fn() {
+  for (int i = 0; i < 10; ++i) {
+    printf("Thread 2: %d Running in a thread!\n", i);
+    sched_task_switch(sched_choose_task(&scheduler));
+  }
+
+  sched_task_destroy(scheduler.current_task);
+}
+
+DEFINE_TEST(sched, coroutines) {
+  sched_init(&scheduler);
+
+  sched_create_task(&scheduler, init_fn);
+  sched_bootstrap_task(&scheduler);
+
+  for (int i = 0; i < 10; ++i) {
+    printf("Thread 1: %d Running in a thread!\n", i);
+    sched_task_switch(sched_choose_task(&scheduler));
+  }
+
+  TEST_ASSERT(true);
+}


### PR DESCRIPTION
Round-robin thread scheduler. `schedule()` (co-operative scheduling) and a timer interrupt (pre-emptive scheduling) are implemented here. Threads can be created and destroyed, but must be done so explicitly with `sched_create_task()` and `sched_destoy_task()`. See comment at top of sched.h.

There is currently no way for threads to wait on other threads/processes or files; this will be implemented in the future with waitqueues for threads/processes and files. User-space processes will likely be the next feature.